### PR TITLE
Fix a floating point bug and introduce a small test suite

### DIFF
--- a/reverse-geocoding.cabal
+++ b/reverse-geocoding.cabal
@@ -28,6 +28,14 @@ library
   hs-source-dirs:     src
   default-language:   Haskell2010
 
+test-suite network-test
+  default-language:   Haskell2010
+  type:               exitcode-stdio-1.0
+  hs-source-dirs:     tests
+  main-is:            NetworkTest.hs
+  build-depends:      base,
+                      reverse-geocoding
+
 source-repository head
   type: git
   location: https://github.com/jcristovao/reverse-geocoding

--- a/src/Data/Geolocation/Reverse/Providers.hs
+++ b/src/Data/Geolocation/Reverse/Providers.hs
@@ -22,6 +22,7 @@ import Data.Aeson
 import Data.Aeson.Types
 import Control.Monad (join)
 import qualified Data.Text as T
+import Text.Printf
 
 import Data.Geolocation.Reverse.Types
 
@@ -41,8 +42,8 @@ openStreetMapUrl (Latitude mlat) (Longitude mlon) = do
   return $  "http://nominatim.openstreetmap.org/reverse"
          <> "?format=json"
          <> "&zoom=18"
-         <> "&lat=" <> show lat
-         <> "&lon=" <> show lon
+         <> "&lat=" <> formatFixed lat
+         <> "&lon=" <> formatFixed lon
 
 
 getPostCodeText :: Suburb -> Maybe Suburb
@@ -77,3 +78,5 @@ openStreetMapParser o =
                           <|?> (o .:? "street")
                          )
                      <*> o .:? "postcode"
+
+formatFixed n = printf "%.6f" n

--- a/tests/NetworkTest.hs
+++ b/tests/NetworkTest.hs
@@ -1,0 +1,9 @@
+import Data.Geolocation.Reverse
+import Data.Geolocation.Reverse.Types
+
+main = do
+  putStrLn "Network test stub"
+  -- all we're going to do is get a location and
+  -- check we don't crash.
+  l <- getLocationInfoDef (Latitude (Just 5)) (Longitude (Just 5))
+  print l

--- a/tests/NetworkTest.hs
+++ b/tests/NetworkTest.hs
@@ -2,8 +2,14 @@ import Data.Geolocation.Reverse
 import Data.Geolocation.Reverse.Types
 
 main = do
-  putStrLn "Network test stub"
+
   -- all we're going to do is get a location and
   -- check we don't crash.
   l <- getLocationInfoDef (Latitude (Just 5)) (Longitude (Just 5))
   print l
+
+  -- regression test for extremely small numbers that
+  -- were being rendered using invalid exponential
+  -- notation.
+  l2 <- getLocationInfoDef (Latitude (Just 0.0005)) (Longitude (Just 0.0005))
+  print l2


### PR DESCRIPTION
Small latitudes and longitudes were previously formatted into an openstreetmap request using `show`.

For small values, this uses exponential notation (for example, 8e-2) which the API cannot accept.

This PR changes to fixed point representation and adds a simple over-the-network test (which can demonstrate the bug if used without the fixed point change)
